### PR TITLE
Add Ordered lattice.

### DIFF
--- a/Algebra/Lattice/Ordered.hs
+++ b/Algebra/Lattice/Ordered.hs
@@ -1,0 +1,97 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+#if __GLASGOW_HASKELL__ < 709
+{-# LANGUAGE Trustworthy #-}
+#else
+{-# LANGUAGE Safe #-}
+#endif
+----------------------------------------------------------------------------
+-- |
+-- Module      :  Algebra.Lattice.Ordered
+-- Copyright   :  (C) 2010-2015 Maximilian Bolingbroke, 2015 Oleg Grenrus
+-- License     :  BSD-3-Clause (see the file LICENSE)
+--
+-- Maintainer  :  Oleg Grenrus <oleg.grenrus@iki.fi>
+--
+----------------------------------------------------------------------------
+module Algebra.Lattice.Ordered (
+    Ordered(..)
+  ) where
+
+#ifndef MIN_VERSION_base
+#define MIN_VERSION_base(x,y,z) 1
+#endif
+
+import Algebra.Lattice
+import Algebra.PartialOrd
+
+#if MIN_VERSION_base(4,8,0)
+#else
+import Control.Applicative
+import Data.Foldable
+import Data.Traversable
+#endif
+
+import Control.DeepSeq
+import Control.Monad
+import Data.Data
+import Data.Hashable
+import GHC.Generics
+
+--
+-- Ordered
+--
+
+-- | A total order gives rise to a lattice. Join is
+-- max, meet is min.
+data Ordered a = Ordered { getOrdered :: a }
+  deriving ( Eq, Ord, Show, Read, Data, Typeable, Generic
+#if __GLASGOW_HASKELL__ >= 706
+           , Generic1
+#endif
+           )
+
+instance Foldable Ordered where
+  foldMap f (Ordered a) = f a
+
+instance Traversable Ordered where
+  traverse f (Ordered a) = Ordered <$> f a
+
+instance Functor Ordered where
+  fmap f (Ordered a) = Ordered (f a)
+
+instance Applicative Ordered where
+  pure = return
+  (<*>) = ap
+
+instance Monad Ordered where
+  return           = Ordered
+  Ordered x >>= f  = f x
+
+instance NFData a => NFData (Ordered a) where
+  rnf (Ordered a) = rnf a
+
+instance Hashable a => Hashable (Ordered a)
+
+instance Ord a => JoinSemiLattice (Ordered a) where
+  Ordered x \/ Ordered y = Ordered (max x y)
+
+instance Ord a => MeetSemiLattice (Ordered a) where
+  Ordered x /\ Ordered y = Ordered (min x y)
+
+instance (Lattice a, Ord a) => Lattice (Ordered a) where
+
+instance (Ord a, Bounded a) => BoundedJoinSemiLattice (Ordered a) where
+  bottom = Ordered minBound
+
+instance (Ord a, Bounded a) => BoundedMeetSemiLattice (Ordered a) where
+  top = Ordered maxBound
+
+instance (BoundedLattice a, Ord a, Bounded a) => BoundedLattice (Ordered a) where
+
+instance Ord a => PartialOrd (Ordered a) where
+    leq = (<=)

--- a/Algebra/Lattice/Ordered.hs
+++ b/Algebra/Lattice/Ordered.hs
@@ -48,7 +48,7 @@ import GHC.Generics
 
 -- | A total order gives rise to a lattice. Join is
 -- max, meet is min.
-data Ordered a = Ordered { getOrdered :: a }
+newtype Ordered a = Ordered { getOrdered :: a }
   deriving ( Eq, Ord, Show, Read, Data, Typeable, Generic
 #if __GLASGOW_HASKELL__ >= 706
            , Generic1

--- a/lattices.cabal
+++ b/lattices.cabal
@@ -26,6 +26,7 @@ library
                     Algebra.Lattice.Dropped,
                     Algebra.Lattice.Levitated,
                     Algebra.Lattice.Lifted,
+                    Algebra.Lattice.Ordered,
                     Algebra.PartialOrd
 
   build-depends:    base                       >= 4.5  && < 4.9,

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -23,6 +23,7 @@ import Test.Tasty.QuickCheck as QC
 import qualified Algebra.Lattice.Dropped as D
 import qualified Algebra.Lattice.Lifted as U
 import qualified Algebra.Lattice.Levitated as L
+import qualified Algebra.Lattice.Ordered as O
 
 -- For old GHC to work
 data Proxy1 (a :: * -> *) = Proxy1
@@ -38,12 +39,15 @@ theseProps = testGroup "These"
   [ functorLaws "Dropped" (Proxy1 :: Proxy1 D.Dropped)
   , functorLaws "Lifted" (Proxy1 :: Proxy1 U.Lifted)
   , functorLaws "Leviated" (Proxy1 :: Proxy1 L.Levitated)
+  , functorLaws "Ordered" (Proxy1 :: Proxy1 O.Ordered)
   , traversableLaws "Dropped" (Proxy1 :: Proxy1 D.Dropped)
   , traversableLaws "Lifted" (Proxy1 :: Proxy1 U.Lifted)
   , traversableLaws "Levitated" (Proxy1 :: Proxy1 L.Levitated)
+  , traversableLaws "Ordered" (Proxy1 :: Proxy1 O.Ordered)
   , monadLaws "Dropped" (Proxy1 :: Proxy1 D.Dropped)
   , monadLaws "Lifted" (Proxy1 :: Proxy1 U.Lifted)
   , monadLaws "Levitated" (Proxy1 :: Proxy1 L.Levitated)
+  , monadLaws "Ordered" (Proxy1 :: Proxy1 O.Ordered)
   ]
 
 functorLaws :: forall (f :: * -> *). ( Functor f
@@ -144,3 +148,6 @@ instance Arbitrary a => Arbitrary (L.Levitated a) where
                         , (1, pure L.Bottom)
                         , (9, L.Levitate <$> arbitrary)
                         ]
+
+instance Arbitrary a => Arbitrary (O.Ordered a) where
+  arbitrary = O.Ordered <$> arbitrary


### PR DESCRIPTION
Turn types with instances of Ord into lattices, and bounded lattices if also instances of Bounded.
This doesn't include a version bump.  I have a couple more changes I'm likely to add in the very near future.

I'm too lazy to do it without GeneralizedNewtypeDeriving, but I'd add derived instances for all the other standard classes.