### PR TITLE
Add HashMap tests and instances

### DIFF
--- a/Algebra/Lattice.hs
+++ b/Algebra/Lattice.hs
@@ -261,6 +261,13 @@ instance (Eq k, Hashable k) => MeetSemiLattice (HM.HashMap k v) where
 instance (Eq k, Hashable k) => BoundedJoinSemiLattice (HM.HashMap k v) where
     bottom = HM.empty
 
+instance (Eq k, Hashable k, Lattice v) => Lattice (HM.HashMap k v) where
+
+instance (Eq k, Hashable k, Finite k, BoundedMeetSemiLattice v) => BoundedMeetSemiLattice (HM.HashMap k v) where
+    top = HM.fromList (universeF `zip` repeat top)
+
+instance (Eq k, Hashable k, Finite k, BoundedLattice v) => BoundedLattice (HM.HashMap k v) where
+
 --
 -- Functions
 --

--- a/Algebra/Lattice.hs
+++ b/Algebra/Lattice.hs
@@ -252,13 +252,13 @@ instance Lattice v => Lattice (IM.IntMap v)
 -- HashMaps
 --
 
-instance (Eq k, Hashable k) => JoinSemiLattice (HM.HashMap k v) where
-    (\/) = HM.union
+instance (Eq k, Hashable k, JoinSemiLattice v) => JoinSemiLattice (HM.HashMap k v) where
+    (\/) = HM.unionWith (\/)
 
-instance (Eq k, Hashable k) => MeetSemiLattice (HM.HashMap k v) where
-    (/\) = HM.intersection
+instance (Eq k, Hashable k, MeetSemiLattice v) => MeetSemiLattice (HM.HashMap k v) where
+    (/\) = HM.intersectionWith (/\)
 
-instance (Eq k, Hashable k) => BoundedJoinSemiLattice (HM.HashMap k v) where
+instance (Eq k, Hashable k, JoinSemiLattice v) => BoundedJoinSemiLattice (HM.HashMap k v) where
     bottom = HM.empty
 
 instance (Eq k, Hashable k, Lattice v) => Lattice (HM.HashMap k v) where

--- a/Algebra/PartialOrd.hs
+++ b/Algebra/PartialOrd.hs
@@ -18,9 +18,13 @@ module Algebra.PartialOrd (
     gfpFrom, unsafeGfpFrom
   ) where
 
+import           Data.Foldable (Foldable (..))
+import           Data.Hashable (Hashable (..))
+import qualified Data.HashMap.Lazy as HM
 import qualified Data.IntMap as IM
 import qualified Data.IntSet as IS
 import qualified Data.Map as M
+import           Data.Monoid (All (..))
 import qualified Data.Set as S
 
 -- | A partial ordering on sets
@@ -105,6 +109,10 @@ instance (Ord k, PartialOrd v) => PartialOrd (M.Map k v) where
 
 instance PartialOrd v => PartialOrd (IM.IntMap v) where
     leq = IM.isSubmapOfBy leq
+
+instance (Eq k, Hashable k, PartialOrd v) => PartialOrd (HM.HashMap k v) where
+    x `leq` y = {- wish: HM.isSubmapOfBy leq -}
+        HM.null (HM.difference x y) && getAll (fold $ HM.intersectionWith (\vx vy -> All (vx `leq` vy)) x y)
 
 instance (PartialOrd a, PartialOrd b) => PartialOrd (a, b) where
     -- NB: *not* a lexical ordering. This is because for some component partial orders, lexical

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -30,6 +30,7 @@ import Data.IntMap (IntMap)
 import Data.IntSet (IntSet)
 import Data.Map (Map)
 import Data.Set (Set)
+import Data.HashMap.Lazy (HashMap)
 
 import Data.Universe.Instances.Base ()
 import Test.QuickCheck.Instances ()
@@ -47,6 +48,7 @@ tests = testGroup "Tests"
   , latticeLaws "M2" True (Proxy :: Proxy M2) -- M2
   , latticeLaws "Map" True (Proxy :: Proxy (Map Int (O.Ordered Int)))
   , latticeLaws "IntMap" True (Proxy :: Proxy (IntMap (O.Ordered Int)))
+  , latticeLaws "HashMap" True (Proxy :: Proxy (HashMap Int (O.Ordered Int)))
   , latticeLaws "Set" True (Proxy :: Proxy (Set Int))
   , latticeLaws "IntSet" True (Proxy :: Proxy IntSet)
   , latticeLaws "Ordered" True (Proxy :: Proxy (O.Ordered Int))


### PR DESCRIPTION
- Add `PartialOrd` instance for HashMap 
  **N.B.** This is a bit unsatisfying since there's no `HashMap.isSubsetOfBy` so we do something with difference and intersection.
- Add `BoundedLattice`, `BoundedMeetSemiLattice` and `Lattice` instances for HashMap
- Add HashMap lattice laws test
- Fix HashMap `JoinSemiLattice` and `MeetSemiLattice` to be lawful instances.  Fixes #50 