### PR TITLE
`partialOrdEq` docs

### DIFF
--- a/src/Algebra/Lattice.hs
+++ b/src/Algebra/Lattice.hs
@@ -353,6 +353,30 @@ instance BoundedMeetSemiLattice Bool where
 
 instance BoundedLattice Bool where
 
+--
+-- Maybe
+--
+
+instance JoinSemiLattice a => JoinSemiLattice (Maybe a) where
+    (Just a) \/ (Just b) = Just (a \/ b)
+    Nothing  \/ b        = b
+    a        \/ Nothing  = a
+
+instance MeetSemiLattice a => MeetSemiLattice (Maybe a) where
+    (Just a) /\ (Just b) = Just (a /\ b)
+    Nothing  /\ _        = Nothing
+    _        /\ Nothing  = Nothing
+
+instance Lattice a => Lattice (Maybe a)
+
+instance JoinSemiLattice a => BoundedJoinSemiLattice (Maybe a) where
+    bottom = Nothing
+
+instance BoundedMeetSemiLattice a => BoundedMeetSemiLattice (Maybe a) where
+    top = Just top
+
+instance BoundedLattice a => BoundedLattice (Maybe a)
+
 --- Monoids
 
 -- | Monoid wrapper for JoinSemiLattice

--- a/src/Algebra/PartialOrd.hs
+++ b/src/Algebra/PartialOrd.hs
@@ -93,10 +93,11 @@ class Eq a => PartialOrd a where
     comparable :: a -> a -> Bool
     comparable x y = leq x y || leq y x
 
--- | The equality relation induced by the partial-order structure. It must obey
--- the laws
+-- | The equality relation induced by the partial-order structure. It satisfies
+-- the laws of an equivalence relation:
 -- @
 -- Reflexive:  a == a
+-- Symmetric:  a == b => b == a
 -- Transitive: a == b && b == c ==> a == c
 -- @
 partialOrdEq :: PartialOrd a => a -> a -> Bool

--- a/src/Algebra/PartialOrd.hs
+++ b/src/Algebra/PartialOrd.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE Safe #-}
+{-# LANGUAGE FlexibleInstances #-}
 ----------------------------------------------------------------------------
 -- |
 -- Module      :  Algebra.PartialOrd
@@ -113,6 +114,11 @@ instance Eq a => PartialOrd [a] where
 
 instance Ord a => PartialOrd (S.Set a) where
     leq = S.isSubsetOf
+
+instance PartialOrd a => PartialOrd (Maybe a) where
+    leq (Just a) (Just b) = leq a b
+    leq (Just _) Nothing  = False
+    leq Nothing  _        = True
 
 instance PartialOrd IS.IntSet where
     leq = IS.isSubsetOf

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -47,6 +47,7 @@ tests :: TestTree
 tests = testGroup "Tests"
   [ latticeLaws "M3" False (Proxy :: Proxy M3) -- non distributive lattice!
   , latticeLaws "M2" True (Proxy :: Proxy M2) -- M2
+  , latticeLaws "Maybe M2" True (Proxy :: Proxy (Maybe M2))
   , latticeLaws "Map" True (Proxy :: Proxy (Map Int (O.Ordered Int)))
   , latticeLaws "IntMap" True (Proxy :: Proxy (IntMap (O.Ordered Int)))
   , latticeLaws "HashMap" True (Proxy :: Proxy (HashMap Int (O.Ordered Int)))


### PR DESCRIPTION
`partialOrdEq` is an equivalence relation whenever the `PartialOrd` instance is lawful (i.e. reflexive, antysymmetric and transitive); this PR updates the documentation to reflect this.