### PR TITLE
Change partialOrdEq documentation

### DIFF
--- a/src/Algebra/PartialOrd.hs
+++ b/src/Algebra/PartialOrd.hs
@@ -92,10 +92,11 @@ class Eq a => PartialOrd a where
     comparable :: a -> a -> Bool
     comparable x y = leq x y || leq y x
 
--- | The equality relation induced by the partial-order structure. It must obey
--- the laws
+-- | The equality relation induced by the partial-order structure. It satisfies
+-- the laws of an equivalence relation:
 -- @
 -- Reflexive:  a == a
+-- Symmetric:  a == b ==> b == a
 -- Transitive: a == b && b == c ==> a == c
 -- @
 partialOrdEq :: PartialOrd a => a -> a -> Bool


### PR DESCRIPTION
`partialOrdEq` is an equivalence relation whenever the `PartialOrd` instance is lawful (i.e. reflexive, antysymmetric and transitive); this PR updates the documentation to reflect this.