### PR TITLE
Add tests for the relationship between leq and compare

### DIFF
--- a/src/Algebra/Lattice/Dropped.hs
+++ b/src/Algebra/Lattice/Dropped.hs
@@ -29,6 +29,7 @@ import Prelude ()
 import Prelude.Compat
 
 import Algebra.Lattice
+import Algebra.PartialOrd
 
 import Control.DeepSeq
 import Control.Monad
@@ -64,6 +65,14 @@ instance NFData a => NFData (Dropped a) where
   rnf (Drop a) = rnf a
 
 instance Hashable a => Hashable (Dropped a)
+
+instance PartialOrd a => PartialOrd (Dropped a) where
+  leq _ Top = True
+  leq Top _ = False
+  leq (Drop x) (Drop y) = leq x y
+  comparable Top _ = True
+  comparable _ Top = True
+  comparable (Drop x) (Drop y) = comparable x y
 
 instance JoinSemiLattice a => JoinSemiLattice (Dropped a) where
     Top    \/ _      = Top

--- a/src/Algebra/Lattice/Levitated.hs
+++ b/src/Algebra/Lattice/Levitated.hs
@@ -29,6 +29,7 @@ import Prelude ()
 import Prelude.Compat
 
 import Algebra.Lattice
+import Algebra.PartialOrd
 
 import Control.DeepSeq
 import Control.Monad
@@ -68,6 +69,18 @@ instance NFData a => NFData (Levitated a) where
   rnf (Levitate a) = rnf a
 
 instance Hashable a => Hashable (Levitated a)
+
+instance PartialOrd a => PartialOrd (Levitated a) where
+  leq _ Top = True
+  leq Top _ = False
+  leq Bottom _ = True
+  leq _ Bottom = False
+  leq (Levitate x) (Levitate y) = leq x y
+  comparable Top _ = True
+  comparable _ Top = True
+  comparable Bottom _ = True
+  comparable _ Bottom = True
+  comparable (Levitate x) (Levitate y) = comparable x y
 
 instance JoinSemiLattice a => JoinSemiLattice (Levitated a) where
     Top        \/ _          = Top

--- a/src/Algebra/Lattice/Lifted.hs
+++ b/src/Algebra/Lattice/Lifted.hs
@@ -29,6 +29,7 @@ import Prelude ()
 import Prelude.Compat
 
 import Algebra.Lattice
+import Algebra.PartialOrd
 
 import Control.DeepSeq
 import Control.Monad
@@ -64,6 +65,14 @@ instance NFData a => NFData (Lifted a) where
   rnf (Lift a) = rnf a
 
 instance Hashable a => Hashable (Lifted a)
+
+instance PartialOrd a => PartialOrd (Lifted a) where
+  leq Bottom _ = True
+  leq _ Bottom = False
+  leq (Lift x) (Lift y) = leq x y
+  comparable Bottom _ = True
+  comparable _ Bottom = True
+  comparable (Lift x) (Lift y) = comparable x y
 
 instance JoinSemiLattice a => JoinSemiLattice (Lifted a) where
     Lift x \/ Lift y = Lift (x \/ y)

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -58,6 +58,11 @@ tests = testGroup "Tests"
   , latticeLaws "LexOrdered" True (Proxy :: Proxy (LO.Lexicographic (O.Ordered Int) (O.Ordered Int)))
   , latticeLaws "Lexicographic" False (Proxy :: Proxy (LO.Lexicographic (Set Bool) (Set Bool)))
   , latticeLaws "Lexicographic" False (Proxy :: Proxy (LO.Lexicographic M2 M2)) -- non distributive!
+  , partialOrdLaws "Dropped" (Proxy :: Proxy (D.Dropped (O.Ordered Int)))
+  , partialOrdLaws "Levitated" (Proxy :: Proxy (L.Levitated (O.Ordered Int)))
+  , partialOrdLaws "Lifted" (Proxy :: Proxy (U.Lifted (O.Ordered Int)))
+  , partialOrdLaws "Op" (Proxy :: Proxy (Op.Op (O.Ordered Int)))
+  , partialOrdLaws "Ordered" (Proxy :: Proxy (O.Ordered Int))
   , testProperty "Lexicographic M2 M2 contains M3" $ QC.property $
       isJust searchM3LexM2
   , monadLaws "Dropped" (Proxy1 :: Proxy1 D.Dropped)
@@ -188,6 +193,23 @@ latticeLaws name distr _ = testGroup ("Lattice laws: " <> name) $
       where
         lhs = x \/ (y /\ z)
         rhs = (x \/ y) /\ (x \/ z)
+
+partialOrdLaws
+    :: forall a. (Eq a, Show a, Arbitrary a, PartialOrd a, Ord a)
+    => String
+    -> Proxy a
+    -> TestTree
+partialOrdLaws name _ = testGroup ("Partial ord laws: " <> name) $
+    [ QC.testProperty "leq/compare are congruent" leqCompareProp
+    ]
+  where
+    leqCompareProp :: a -> a -> Property
+    leqCompareProp x y = agree (leq x y) (leq y x) (compare x y)
+      where
+        agree True True = (=== EQ)
+        agree True False = (=== LT)
+        agree False True = (=== GT)
+        agree False False = discard
 
 -------------------------------------------------------------------------------
 -- Orphans


### PR DESCRIPTION
This patch adds a test for the relationship between `leq` and `compare`: 

```
if x leq y,
 if y leq x,
    x compare y should be EQ
  else
    x compare y should be LT
else
  x compare y should be GT
```

The test suite is failing because the derived instances of `Ord` for the newtypes `Dropped`, etc. violate this property (the constructors are backwards)